### PR TITLE
chore: Upgrade Django-allauth from 0.39.1 to 0.42.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,2 @@
 Django==2.2.15
-django-allauth==0.39.1
+django-allauth==0.42.0


### PR DESCRIPTION
This upgrade is need to order to update upgrade Django to version 3.0.9