### PR TITLE
chore: Upgrade Django from version 3.0.9 to 3.1

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,2 @@
-Django==3.0.9
+Django==3.1
 django-allauth==0.42.0


### PR DESCRIPTION
Upgrade to the latest version of Django. 